### PR TITLE
Disable cpplint.py by default

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,8 @@ class SQLiteCppConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     url = "https://github.com/AlbanSeurat/conan-sqlitecpp"
     license = "MIT"
+    options = {"lint": [True, False]}
+    default_options = "lint=False"
     # No exports necessary
 
     def source(self):
@@ -13,7 +15,8 @@ class SQLiteCppConan(ConanFile):
 
     def build(self):
         cmake = CMake(self.settings)
-        self.run('cmake %s/SQLiteCpp %s' % (self.conanfile_directory, cmake.command_line))
+        lint = "-DSQLITECPP_RUN_CPPLINT=0" if not self.options.lint else ""
+        self.run('cmake %s/SQLiteCpp %s %s' % (self.conanfile_directory, cmake.command_line, lint))
         self.run("cmake --build . %s" % cmake.build_config)
 
     def package(self):


### PR DESCRIPTION
The upstream project uses `cpplint.py` to check for Google Style Guide compliance unless `SQLITECPP_RUN_CPPLINT` is disabled during the build. Sadly, due to https://github.com/google/styleguide/issues/132, the script fails silently with exit code 1 when Python 3 is set as the default interpreter, resulting in stuff like this:

```
Fehler beim Buildvorgang.

"D:\.conan\SQLiteCpp\2.0.0\AlbanSeurat\testing\build\e0a02d496bbb652b6295152dfce0d3937acc0b56\ALL_BUILD.vcxproj" (Standardziel) (1) ->
"D:\.conan\SQLiteCpp\2.0.0\AlbanSeurat\testing\build\e0a02d496bbb652b6295152dfce0d3937acc0b56\SQLiteCpp_cpplint.vcxproj" (Standardziel) (4) ->
(CustomBuild Ziel) ->
  C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppCommon.targets(170,5): error MSB6006: "cmd.exe" wurde mit dem Code 1 beendet. [D:\.conan\
SQLiteCpp\2.0.0\AlbanSeurat\testing\build\e0a02d496bbb652b6295152dfce0d3937acc0b56\SQLiteCpp_cpplint.vcxproj]

    0 Warnung(en)
    1 Fehler
```

Worse, even if it works the linter seems to be picky about line endings that might be defaulted to something unexpected (but otherwise valid) during the git clone.

This PR adds an option to disable the linter, which is set to `False` by default.