### PR TITLE
added FindSQLiteCpp.cmake

### DIFF
--- a/FindSQLiteCpp.cmake
+++ b/FindSQLiteCpp.cmake
@@ -1,0 +1,30 @@
+# Try to find SQLiteCpp
+# Once done, this will define
+#
+# SQLiteCpp_FOUND        - system has SQLiteCpp
+# SQLiteCpp_INCLUDE_DIRS - SQLiteCpp include directories
+# SQLiteCpp_LIBRARIES    - libraries needed to use SQLiteCpp
+
+find_path(
+	SQLiteCpp_INCLUDE_DIR
+	NAMES SQLiteCpp/SQLiteCpp.h
+	PATHS ${CONAN_INCLUDE_DIRS_SQLiteCpp}
+)
+
+find_library(
+	SQLiteCpp_LIBRARY
+	NAMES SQLiteCpp
+	PATHS ${CONAN_LIB_DIRS_SQLiteCpp}
+)
+
+find_library(
+    SQLITE3_LIBRARY
+    NAMES sqlite3
+    PATHS ${CONAN_LIB_DIRS_SQLiteCpp}
+)
+
+set(SQLiteCpp_FOUND TRUE)
+set(SQLiteCpp_INCLUDE_DIRS ${SQLiteCpp_INCLUDE_DIR})
+set(SQLiteCpp_LIBRARIES ${SQLiteCpp_LIBRARY} ${SQLITE3_LIBRARY})
+
+mark_as_advanced(SQLiteCpp_LIBRARY SQLiteCpp_INCLUDE_DIR SQLITE3_LIBRARY)

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ class SQLiteCppConan(ConanFile):
     license = "MIT"
     options = {"lint": [True, False]}
     default_options = "lint=False"
-    # No exports necessary
+    exports = "FindSQLiteCpp.cmake"
 
     def source(self):
         self.run("git clone https://github.com/SRombauts/SQLiteCpp.git")
@@ -20,6 +20,7 @@ class SQLiteCppConan(ConanFile):
         self.run("cmake --build . %s" % cmake.build_config)
 
     def package(self):
+        self.copy("FindSQLiteCpp.cmake", ".", ".")
         self.copy("*.h", dst="include", src="SQLiteCpp/include")
         self.copy("*.lib", dst="lib", src=".", keep_path=False)
         self.copy("*.a", dst="lib", src=".", keep_path=False)


### PR DESCRIPTION
Provided a `FindSQLiteCpp.cmake` so that after

```
include_directories (${OpenCV_INCLUDE_DIR})
include_directories (${Boost_INCLUDE_DIRS})
```

you can

```
find_package (SQLiteCpp)
include_directories (${SQLiteCpp_INCLUDE_DIRS})
```